### PR TITLE
can list and detail comps, added if to template to check for decommission for dynamic render

### DIFF
--- a/hrapp/models/__init__.py
+++ b/hrapp/models/__init__.py
@@ -4,3 +4,4 @@ from .employee_computer import EmployeeComputer
 from .training_program import TrainingProgram
 from .employee_training_program import EmployeeTrainingProgram
 from .department import Department 
+from .model_factory import model_factory

--- a/hrapp/models/model_factory.py
+++ b/hrapp/models/model_factory.py
@@ -1,0 +1,12 @@
+import sqlite3
+
+# Higher order function to create instances of models
+# when performing single table queries
+def model_factory(model_type):
+    def create(cursor, row):
+        instance = model_type()
+        smart_row = sqlite3.Row(cursor, row)
+        for col in smart_row.keys():
+            setattr(instance, col, smart_row[col])
+        return instance
+    return create

--- a/hrapp/templates/computers/detail.html
+++ b/hrapp/templates/computers/detail.html
@@ -1,0 +1,16 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Computer</title>
+  </head>
+  <body>
+    <h1>{{ computer.manufacturer }} {{ computer.make }}</h1>
+
+    <h3>Purchased: {{ computer.purchase_date }}</h3>
+    {% if computer.decommission_date %}
+        <h3>Decommissioned on: {{ computer.decommission_date }}</h3>
+    {% endif %}
+  </body>
+</html>

--- a/hrapp/templates/computers/list.html
+++ b/hrapp/templates/computers/list.html
@@ -1,0 +1,19 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon</title>
+  </head>
+  <body>
+    <h1>Computers</h1>
+
+    <ol>
+    {% for computer in all_computers %}
+        <li>
+            <a href="{% url 'hrapp:computer' computer.id %}"> {{ computer.manufacturer }} {{ computer.make }}</a>
+        </li>
+    {% endfor %}
+    </ol>
+  </body>
+</html>

--- a/hrapp/urls.py
+++ b/hrapp/urls.py
@@ -9,4 +9,6 @@ urlpatterns = [
     path('accounts/', include('django.contrib.auth.urls')),
     path('logout/', logout_user, name='logout'),
     path('employees/', employee_list, name='employee_list'),
+    path('computers/', computer_list, name='computers'),
+    path('computers/<int:computer_id>/', computer_details, name='computer'),
 ]

--- a/hrapp/views/__init__.py
+++ b/hrapp/views/__init__.py
@@ -1,3 +1,5 @@
 from .employees.employee_list import employee_list
+from .computers.comp_list import computer_list
+from .computers.comp_details import computer_details
 from .home import home
 from .auth.logout import logout_user

--- a/hrapp/views/computers/comp_details.py
+++ b/hrapp/views/computers/comp_details.py
@@ -1,0 +1,36 @@
+import sqlite3
+from django.urls import reverse
+from django.shortcuts import render, redirect
+from hrapp.models import model_factory, Computer
+from ..connection import Connection
+
+
+def get_computer(computer_id):
+    with sqlite3.connect(Connection.db_path) as conn:
+        conn.row_factory = model_factory(Computer)
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+            select
+                c.id,
+                c.make,
+                c.manufacturer,
+                c.purchase_date,
+                c.decommission_date
+            from hrapp_computer c
+            WHERE c.id = ?
+        """, (computer_id,))
+
+        return db_cursor.fetchone()
+
+
+def computer_details(request, computer_id):
+    if request.method == 'GET':
+        computer = get_computer(computer_id)
+
+        template = 'computers/detail.html'
+        context = {
+            'computer': computer
+        }
+
+        return render(request, template, context)

--- a/hrapp/views/computers/comp_list.py
+++ b/hrapp/views/computers/comp_list.py
@@ -1,0 +1,41 @@
+import sqlite3
+from django.shortcuts import render
+from hrapp.models import Computer
+from ..connection import Connection
+
+
+def computer_list(request):
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            db_cursor.execute("""
+            select
+                c.id,
+                c.make,
+                c.manufacturer,
+                c.purchase_date,
+                c.decommission_date
+            from hrapp_computer c
+            """)
+
+            all_computers = []
+            dataset = db_cursor.fetchall()
+
+            for row in dataset:
+                computer = Computer()
+                computer.id = row['id']
+                computer.make = row['make']
+                computer.manufacturer = row['manufacturer']
+                computer.purchase_date = row['purchase_date']
+                computer.decommission_date = row['decommission_date']
+
+                all_computers.append(computer)
+
+        template = 'computers/list.html'
+        context = {
+            'all_computers': all_computers
+        }
+
+        return render(request, template, context)


### PR DESCRIPTION

git fetch --all
git checkout (MK-complist)

Make an SQL query and run these to add 2 new comps in tableplus:

INSERT INTO hrapp_computer(make, manufacturer, purchase_date, decommission_date)
VALUES('XPS 15', 'Dell', '4/20/2020', NULL);

INSERT INTO hrapp_computer(make, manufacturer, purchase_date, decommission_date)
VALUES('MacBook Pro', 'Apple', '3/10/2010', '3/10/2015');


Summary of this pull request:
Added "/computers" url to show list of computers in database, with clickable links for details on each with dynamic template to check for decommission or not.

List of specifics:
-Lists all computers
-Show details of computers
-Dynamic render based on if comp is active


Something you'd rather be doing:
Taking a nap. 😛 
