### PR TITLE
kw-training-program-delete

### DIFF
--- a/hrapp/templates/training_programs/training_program_detail.html
+++ b/hrapp/templates/training_programs/training_program_detail.html
@@ -7,6 +7,10 @@
     <h2>End Date: {{training_program.end_date}}</h2>
     <h2>Capacity: {{training_program.capacity}}</h2>
     <a class='bangazonButton'>Edit</a>
-    <a class='bangazonButton'>Delete</a>
 
+    <form action="{% url 'hrapp:training_program_details' training_program.id %}" method="POST">
+    {% csrf_token %}
+    <input type="hidden" name="actual_method" value="DELETE">
+    <button class='bangazonButton'>Delete</button>
+    </form>
 {% endblock content %}

--- a/hrapp/views/training_programs/detail.py
+++ b/hrapp/views/training_programs/detail.py
@@ -31,3 +31,20 @@ def training_program_details(request, training_program_id):
             'training_program': training_program
         }
         return render(request, template, context)
+
+    if(request.method) == 'POST':
+        form_data = request.POST
+
+        if (
+            "actual_method" in form_data
+            and form_data["actual_method"] == "DELETE"
+        ):
+            with sqlite3.connect(Connection.db_path) as conn:
+                db_cursor = conn.cursor()
+
+                db_cursor.execute("""
+                DELETE FROM hrapp_trainingprogram
+                WHERE id = ?
+                """, (training_program_id,))
+
+            return redirect(reverse('hrapp:training_program_list'))


### PR DESCRIPTION
closes #12 
git fetch --all
git checkout kw-training-program-delete
Summary of this pull request: Delete functionality for training programs

List of specifics:
- There should be a delete button on the detail page of every training program
- Clicking 'Delete' will remove the training program from the database and redirect you to the list of training programs


Something you'd rather be doing:
Attending a REAL job fair